### PR TITLE
Hw1 flask

### DIFF
--- a/HW/HW2 Docker/flask/Dockerfile
+++ b/HW/HW2 Docker/flask/Dockerfile
@@ -16,11 +16,13 @@ COPY . /app
 # RUN pip install --no-cache-dir -r requirements.txt
 RUN pip install flask
 
+ENV PORT=5002
+
 # Port 5000 is the default value for flask apps
 # Make port 5000 available to the world outside this container
 # Note that this is for the purposes of documentation
 # The port is actually exposed when you run the container from the command line
-EXPOSE 5000
+EXPOSE $PORT
 
 # Run app.py when the container launches
 CMD ["python3", "app.py"]
@@ -28,3 +30,10 @@ CMD ["python3", "app.py"]
 # Health check (checks every 30 seconds to see if the endpoint returns a successful response)
 # HEALTHCHECK --interval=30s --timeout=3s \
 #  CMD curl -f http://localhost:5000/healthcheck || exit 1
+
+# Health check (checks every 30 seconds to see if the endpoint 
+# returns a successful response)
+
+HEALTHCHECK --interval=30s --timeout=3s \
+
+CMD curl -f http://localhost:${PORT}/healthcheck || exit 1

--- a/HW/HW2 Docker/flask/app.py
+++ b/HW/HW2 Docker/flask/app.py
@@ -11,7 +11,7 @@ def hello():
         }
     )
     return response
-
+# comment
 if __name__ == '__main__':
     # By default flask is only accessible from localhost.
     # Set this to '0.0.0.0' to make it accessible from any IP address

--- a/HW/HW2 Docker/flask/app.py
+++ b/HW/HW2 Docker/flask/app.py
@@ -1,4 +1,5 @@
-from flask import Flask, make_response
+from flask import Flask, make_response, request
+import os 
 
 app = Flask(__name__)
 
@@ -11,9 +12,38 @@ def hello():
         }
     )
     return response
-# comment
+
+@app.route('/repeat', methods=['GET'])
+def repeat():
+    input= request.args.get('input','')
+    response = make_response(
+        {
+            'body': input,
+            'status': 200
+        }
+    )
+    return response
+
+@app.route('/health')
+@app.route('/healthcheck')
+def health():
+    response = make_response(
+        {
+            'body': 'OK',
+            'status': 200
+        }
+    )
+    return response
+
+@app.route('/hang')
+def hang():
+    while True:
+        pass
+
 if __name__ == '__main__':
     # By default flask is only accessible from localhost.
     # Set this to '0.0.0.0' to make it accessible from any IP address
     # on your network (not recommended for production use)
-    app.run(host='0.0.0.0', debug=True)
+
+    PORT =os.getenv("PORT")
+    app.run(host='0.0.0.0', port = PORT, debug=True, threaded=False)


### PR DESCRIPTION

1. 
Docker:
* Serving Flask app 'app'
 * Debug mode: on
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:5002
 * Running on http://172.17.0.2:5002
Press CTRL+C to quit
 * Restarting with stat
 * Debugger is active!
 * Debugger PIN: 807-310-070
172.17.0.1 - - [10/Feb/2025 00:01:24] "GET / HTTP/1.1" 200 -


Curl: 
(base) crc-dot1x-nat-10-239-35-243:411-resources aaronhuang$ curl localhost:5002
{
  "response": "Hello, World!",
  "status": 200
}



2. 
(base) crc-dot1x-nat-10-239-35-243:411-resources aaronhuang$ curl "localhost:5002/repeat?input=foo"
{
  "body": "foo",
  "status": 200
}


3. 
Health:

(base) crc-dot1x-nat-10-239-35-243:411-resources aaronhuang$ curl localhost:5002/health
{
  "body": "OK",
  "status": 200
}

Healthcheck:
(base) crc-dot1x-nat-10-239-35-243:411-resources aaronhuang$ curl localhost:5002/healthcheck
{
  "body": "OK",
  "status": 200
}

4. 
(base) crc-dot1x-nat-10-239-35-243:411-resources aaronhuang$ docker ps --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
CONTAINER ID   NAMES               STATUS
5c4e09a074cd   flamboyant_napier   Up 18 seconds (health: starting)
(base) crc-dot1x-nat-10-239-35-243:411-resources aaronhuang$ docker ps --format "table {{.ID}}\t{{.Names}}\t{{.Status}}"
CONTAINER ID   NAMES               STATUS
5c4e09a074cd   flamboyant_napier   Up About a minute (unhealthy)